### PR TITLE
FR1.4: Add logout API route

### DIFF
--- a/user-service/constants.js
+++ b/user-service/constants.js
@@ -1,0 +1,2 @@
+export const REDIS_JWT_KEY = 'invalid_jwt'
+export const JWT_EXPIRY = 7 * 24 * 60 * 60 // 7 days in seconds

--- a/user-service/controller/user-controller.js
+++ b/user-service/controller/user-controller.js
@@ -66,8 +66,10 @@ export const logoutUser = async (req, res) => {
 
   const invalidationResult = await _invalidateJWT(token)
   if (invalidationResult) {
-    return res.status(200).send('User logged out - token invalidated.')
+    return res
+      .status(200)
+      .json({ messsage: 'User logged out - token invalidated.' })
   } else {
-    return res.status(500).send('Failed to invalidate user token')
+    return res.status(500).json({ message: 'Failed to invalidate user token' })
   }
 }

--- a/user-service/index.js
+++ b/user-service/index.js
@@ -6,7 +6,11 @@ app.use(express.urlencoded({ extended: true }))
 app.use(express.json())
 app.use(cors()) // config cors so that front-end can use
 app.options('*', cors())
-import { createUser, loginUser } from './controller/user-controller.js'
+import {
+  createUser,
+  loginUser,
+  logoutUser,
+} from './controller/user-controller.js'
 
 const router = express.Router()
 
@@ -14,6 +18,7 @@ const router = express.Router()
 router.get('/', (_, res) => res.send('Hello World from user-service'))
 router.post('/', createUser)
 router.post('/login', loginUser)
+router.post('/logout', logoutUser)
 
 app.use('/api/user', router).all((_, res) => {
   res.setHeader('content-type', 'application/json')

--- a/user-service/index.js
+++ b/user-service/index.js
@@ -10,6 +10,7 @@ import {
   createUser,
   loginUser,
   logoutUser,
+  deleteUser,
 } from './controller/user-controller.js'
 
 const router = express.Router()
@@ -17,6 +18,7 @@ const router = express.Router()
 // Controller will contain all the User-defined Routes
 router.get('/', (_, res) => res.send('Hello World from user-service'))
 router.post('/', createUser)
+router.delete('/', deleteUser)
 router.post('/login', loginUser)
 router.post('/logout', logoutUser)
 

--- a/user-service/model/redis_repository.js
+++ b/user-service/model/redis_repository.js
@@ -1,0 +1,21 @@
+import { createClient } from 'redis'
+import { REDIS_JWT_KEY, JWT_EXPIRY } from '../constants.js'
+
+const client = createClient()
+client.on('error', (err) => console.error('Redis client connection error', err))
+client.on('connect', () => console.log('REDIS CONNECTED'))
+await client.connect()
+
+const getTokenKey = (token) => `${REDIS_JWT_KEY}_${token}`
+
+export const addJWT = async (token) => {
+  const token_key = getTokenKey(token)
+  await client.set(token_key, token)
+  return client.expire(token_key, JWT_EXPIRY) // returns 1 if successfully set, 0 otherwise
+}
+
+export const checkJWTExists = async (token) => {
+  const token_key = getTokenKey(token)
+  const isTokenBlacklisted = await client.get(token_key)
+  return !!isTokenBlacklisted
+}

--- a/user-service/model/repository.js
+++ b/user-service/model/repository.js
@@ -18,6 +18,8 @@ export async function createUser(params) {
   return new UserModel(params)
 }
 
+export const deleteUser = async (query) => UserModel.deleteOne(query)
+
 export const findUser = async (query) => UserModel.findOne(query)
 
 export const checkIfUserExists = async (query) => UserModel.exists(query)

--- a/user-service/model/user-orm.js
+++ b/user-service/model/user-orm.js
@@ -1,4 +1,8 @@
 import { createUser, findUser, checkIfUserExists } from './repository.js'
+import {
+  addJWT as addJWTToRedis,
+  checkJWTExists as checkJWTExistsRedis,
+} from './redis_repository.js'
 
 // need to separate orm functions from repository to decouple business logic from persistence
 export async function ormCreateUser(username, password) {
@@ -27,6 +31,24 @@ export const ormCheckIfUserExists = async (username) => {
     return userIsFound ? false : true
   } catch (err) {
     console.log('ERROR: Could not check if user exists')
+    return { err }
+  }
+}
+
+export const ormInvalidateJWT = async (token) => {
+  try {
+    return addJWTToRedis(token)
+  } catch (err) {
+    console.log('ERROR: Could not save JWT to redis blacklist')
+    return { err }
+  }
+}
+
+export const ormIsJWTValid = async (token) => {
+  try {
+    return !checkJWTExistsRedis(token)
+  } catch (err) {
+    console.log('ERROR: Could not query redis JWT blacklist')
     return { err }
   }
 }

--- a/user-service/model/user-orm.js
+++ b/user-service/model/user-orm.js
@@ -1,4 +1,9 @@
-import { createUser, findUser, checkIfUserExists } from './repository.js'
+import {
+  createUser,
+  deleteUser,
+  findUser,
+  checkIfUserExists,
+} from './repository.js'
 import {
   addJWT as addJWTToRedis,
   checkJWTExists as checkJWTExistsRedis,
@@ -12,6 +17,15 @@ export async function ormCreateUser(username, password) {
     return true
   } catch (err) {
     console.log('ERROR: Could not create new user')
+    return { err }
+  }
+}
+
+export const ormDeleteUser = async (username) => {
+  try {
+    return await deleteUser({ username })
+  } catch (err) {
+    console.log('ERROR: Could not delete user')
     return { err }
   }
 }

--- a/user-service/package-lock.json
+++ b/user-service/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "user-service",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
@@ -14,7 +13,8 @@
         "dotenv": "^16.0.1",
         "express": "^4.18.1",
         "jsonwebtoken": "^8.5.1",
-        "mongoose": "^6.4.5"
+        "mongoose": "^6.4.5",
+        "redis": "^4.3.1"
       },
       "devDependencies": {
         "nodemon": "^2.0.19"
@@ -65,6 +65,59 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.0.2.tgz",
+      "integrity": "sha512-EBw7Ag1hPgFzdznK2PBblc1kdlj5B5Cw3XwI9/oG7tSn85/HKy3X9xHy/8tm/eNXJYHLXHJL/pkwBpFMVVefkw==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.3.0.tgz",
+      "integrity": "sha512-XCFV60nloXAefDsPnYMjHGtvbtHR8fV5Om8cQ0JYqTNbWcQo/4AryzJ2luRj4blveWazRK/j40gES8M7Cp6cfQ==",
+      "dependencies": {
+        "cluster-key-slot": "1.1.0",
+        "generic-pool": "3.8.2",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.0.1.tgz",
+      "integrity": "sha512-oDE4myMCJOCVKYMygEMWuriBgqlS5FqdWerikMoJxzmmTUErnTRRgmIDa2VcgytACZMFqpAOWDzops4DOlnkfQ==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.4.tgz",
+      "integrity": "sha512-LUZE2Gdrhg0Rx7AN+cZkb1e6HjoSKaeeW8rYnt89Tly13GBI5eP4CwDVr+MY8BAYfCg4/N15OUrtLoona9uSgw==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.1.0.tgz",
+      "integrity": "sha512-NyFZEVnxIJEybpy+YskjgOJRNsfTYqaPbK/Buv6W2kmFNaRk85JiqjJZA5QkRmWvGbyQYwoO5QfDi2wHskKrQQ==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.3.tgz",
+      "integrity": "sha512-OFp0q4SGrTH0Mruf6oFsHGea58u8vS/iI5+NpYdicaM+7BgqBZH8FFvNZ8rYYLrUO/QRqMq72NpXmxLVNcdmjA==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
       }
     },
     "node_modules/@types/node": {
@@ -373,6 +426,14 @@
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/color-support": {
@@ -695,6 +756,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.8.2.tgz",
+      "integrity": "sha512-nGToKy6p3PAbYQ7p1UlWl6vSPwfwU6TMSWK7TTu+WUY4ZjyZQGniGGt2oNVvyNSpyZYSB43zMXVLcBm08MTMkg==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1515,6 +1584,19 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redis": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.3.1.tgz",
+      "integrity": "sha512-cM7yFU5CA6zyCF7N/+SSTcSJQSRMEKN0k0Whhu6J7n9mmXRoXugfWDBo5iOzGwABmsWKSwGPTU5J4Bxbl+0mrA==",
+      "dependencies": {
+        "@redis/bloom": "1.0.2",
+        "@redis/client": "1.3.0",
+        "@redis/graph": "1.0.1",
+        "@redis/json": "1.0.4",
+        "@redis/search": "1.1.0",
+        "@redis/time-series": "1.0.3"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -1940,6 +2022,46 @@
         }
       }
     },
+    "@redis/bloom": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.0.2.tgz",
+      "integrity": "sha512-EBw7Ag1hPgFzdznK2PBblc1kdlj5B5Cw3XwI9/oG7tSn85/HKy3X9xHy/8tm/eNXJYHLXHJL/pkwBpFMVVefkw==",
+      "requires": {}
+    },
+    "@redis/client": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.3.0.tgz",
+      "integrity": "sha512-XCFV60nloXAefDsPnYMjHGtvbtHR8fV5Om8cQ0JYqTNbWcQo/4AryzJ2luRj4blveWazRK/j40gES8M7Cp6cfQ==",
+      "requires": {
+        "cluster-key-slot": "1.1.0",
+        "generic-pool": "3.8.2",
+        "yallist": "4.0.0"
+      }
+    },
+    "@redis/graph": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.0.1.tgz",
+      "integrity": "sha512-oDE4myMCJOCVKYMygEMWuriBgqlS5FqdWerikMoJxzmmTUErnTRRgmIDa2VcgytACZMFqpAOWDzops4DOlnkfQ==",
+      "requires": {}
+    },
+    "@redis/json": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.4.tgz",
+      "integrity": "sha512-LUZE2Gdrhg0Rx7AN+cZkb1e6HjoSKaeeW8rYnt89Tly13GBI5eP4CwDVr+MY8BAYfCg4/N15OUrtLoona9uSgw==",
+      "requires": {}
+    },
+    "@redis/search": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.1.0.tgz",
+      "integrity": "sha512-NyFZEVnxIJEybpy+YskjgOJRNsfTYqaPbK/Buv6W2kmFNaRk85JiqjJZA5QkRmWvGbyQYwoO5QfDi2wHskKrQQ==",
+      "requires": {}
+    },
+    "@redis/time-series": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.3.tgz",
+      "integrity": "sha512-OFp0q4SGrTH0Mruf6oFsHGea58u8vS/iI5+NpYdicaM+7BgqBZH8FFvNZ8rYYLrUO/QRqMq72NpXmxLVNcdmjA==",
+      "requires": {}
+    },
     "@types/node": {
       "version": "18.0.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.6.tgz",
@@ -2163,6 +2285,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+    },
+    "cluster-key-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
     },
     "color-support": {
       "version": "1.1.3",
@@ -2424,6 +2551,11 @@
         "strip-ansi": "^6.0.1",
         "wide-align": "^1.1.2"
       }
+    },
+    "generic-pool": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.8.2.tgz",
+      "integrity": "sha512-nGToKy6p3PAbYQ7p1UlWl6vSPwfwU6TMSWK7TTu+WUY4ZjyZQGniGGt2oNVvyNSpyZYSB43zMXVLcBm08MTMkg=="
     },
     "get-intrinsic": {
       "version": "1.1.2",
@@ -3022,6 +3154,19 @@
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "redis": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.3.1.tgz",
+      "integrity": "sha512-cM7yFU5CA6zyCF7N/+SSTcSJQSRMEKN0k0Whhu6J7n9mmXRoXugfWDBo5iOzGwABmsWKSwGPTU5J4Bxbl+0mrA==",
+      "requires": {
+        "@redis/bloom": "1.0.2",
+        "@redis/client": "1.3.0",
+        "@redis/graph": "1.0.1",
+        "@redis/json": "1.0.4",
+        "@redis/search": "1.1.0",
+        "@redis/time-series": "1.0.3"
       }
     },
     "rimraf": {

--- a/user-service/package.json
+++ b/user-service/package.json
@@ -21,7 +21,8 @@
     "dotenv": "^16.0.1",
     "express": "^4.18.1",
     "jsonwebtoken": "^8.5.1",
-    "mongoose": "^6.4.5"
+    "mongoose": "^6.4.5",
+    "redis": "^4.3.1"
   },
   "prettier": {
     "tabWidth": 2,


### PR DESCRIPTION
- Added a new `POST /logout` route to user-service that allows users to log out by invalidating their JWT. To do this, I followed [this guide](https://supertokens.com/blog/revoking-access-with-a-jwt-blacklist). In general, most Google results speak the same few things:
  - Blacklisting JWTs isn't really necessary in user logout operations and kinda goes against why we use stateless JWTs in the first place lmao. But no choice cos FR1.4 requires it. The alternative is just to delete the JWT cookie from the client.
  - An in-memory store is usually used to maintain the blacklist to make auth checks performant (i.e. we need to query the store every single time to check if a jwt has been blacklisted). I went with Redis since that's what most people use nowadays anyway and it's quite straightforward.
 
Since we're using Redis, you'll have to [install and run Redis locally](https://redis.io/docs/getting-started/). This should be quite simple 🤞🏻 Eventually when we do deploy the project, we can just add a redis container to our docker-compose.

Lemme know if you guys prefer any other persistence layer!