### PR TITLE
FR 1.4 & 1.5 frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5,11 +5,11 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",
+        "@mui/icons-material": "^5.10.3",
         "@mui/material": "^5.9.1",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
@@ -1810,9 +1810,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.6.tgz",
-      "integrity": "sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
+      "integrity": "sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -3151,6 +3151,31 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.10.3",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.10.3.tgz",
+      "integrity": "sha512-o0kbUlsWCBtCE0wP33cGKbyryCh7kpm2EECYMPDmWrLhbA+HUODXIdhiTFS26szp2xXo9HY1lEx0ufeJ+tddYw==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.9"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@mui/material": {
       "version": "5.9.1",
@@ -18553,9 +18578,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.6.tgz",
-      "integrity": "sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
+      "integrity": "sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -19491,6 +19516,14 @@
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
           "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
         }
+      }
+    },
+    "@mui/icons-material": {
+      "version": "5.10.3",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.10.3.tgz",
+      "integrity": "sha512-o0kbUlsWCBtCE0wP33cGKbyryCh7kpm2EECYMPDmWrLhbA+HUODXIdhiTFS26szp2xXo9HY1lEx0ufeJ+tddYw==",
+      "requires": {
+        "@babel/runtime": "^7.18.9"
       }
     },
     "@mui/material": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
+    "@mui/icons-material": "^5.10.3",
     "@mui/material": "^5.9.1",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,13 @@ import LoginPage from './pages/LoginPage'
 import HomePage from './pages/HomePage'
 import ProfilePage from './pages/ProfilePage'
 import NavBar from './components/NavBar'
+import {
+  baseUrl,
+  signupUrl,
+  loginUrl,
+  homeUrl,
+  profileUrl,
+} from './utils/routeConstants'
 
 const App = () => {
   return (
@@ -12,11 +19,11 @@ const App = () => {
       <Router>
         <NavBar />
         <Routes>
-          <Route exact path="/" element={<LandingPage />} />
-          <Route path="/signup" element={<SignupPage />} />
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/home" element={<HomePage />} />
-          <Route path="/profile" element={<ProfilePage />} />
+          <Route exact path={baseUrl} element={<LandingPage />} />
+          <Route path={signupUrl} element={<SignupPage />} />
+          <Route path={loginUrl} element={<LoginPage />} />
+          <Route path={homeUrl} element={<HomePage />} />
+          <Route path={profileUrl} element={<ProfilePage />} />
         </Routes>
       </Router>
     </div>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,22 +4,21 @@ import SignupPage from './pages/SignupPage'
 import LoginPage from './pages/LoginPage'
 import HomePage from './pages/HomePage'
 import ProfilePage from './pages/ProfilePage'
-import { Box } from '@mui/material'
+import NavBar from './components/NavBar'
 
 const App = () => {
   return (
     <div className="App">
-      <Box display={'flex'} flexDirection={'column'} padding={'4rem'}>
-        <Router>
-          <Routes>
-            <Route exact path="/" element={<LandingPage />} />
-            <Route path="/signup" element={<SignupPage />} />
-            <Route path="/login" element={<LoginPage />} />
-            <Route path="/home" element={<HomePage />} />
-            <Route path="/profile" element={<ProfilePage />} />
-          </Routes>
-        </Router>
-      </Box>
+      <Router>
+        <NavBar />
+        <Routes>
+          <Route exact path="/" element={<LandingPage />} />
+          <Route path="/signup" element={<SignupPage />} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/home" element={<HomePage />} />
+          <Route path="/profile" element={<ProfilePage />} />
+        </Routes>
+      </Router>
     </div>
   )
 }

--- a/frontend/src/api/userService.js
+++ b/frontend/src/api/userService.js
@@ -28,7 +28,9 @@ export const logoutUser = async () => {
   return res
 }
 
-// include signup user
+export const signupUser = async (username, password) =>
+  await axios.post(URL_USER_SVC, { username, password })
+
 export const deleteUser = async (username) => {
   const token = getJWT()
   const res = await axios.delete(URL_USER_SVC, { data: { username, token } })

--- a/frontend/src/api/userService.js
+++ b/frontend/src/api/userService.js
@@ -20,11 +20,7 @@ export const loginUser = async (username, password) => {
 }
 
 export const logoutUser = async () => {
-  const token = Cookies.get(COOKIES_AUTH_TOKEN)
-  if (!token) {
-    throw new Error('JWT not found in cookies.')
-  }
-
+  const token = getJWT()
   const res = await axios.post(URL_USER_LOGOUT_SVC, { token })
   if (res?.status === STATUS_CODE_SUCCESS) {
     Cookies.remove(COOKIES_AUTH_TOKEN)
@@ -33,9 +29,26 @@ export const logoutUser = async () => {
 }
 
 // include signup user
+export const deleteUser = async (username) => {
+  const token = getJWT()
+  const res = await axios.delete(URL_USER_SVC, { data: { username, token } })
+  if (res?.status === STATUS_CODE_SUCCESS) {
+    Cookies.remove(COOKIES_AUTH_TOKEN)
+  }
+  return res
+}
 
 export const changeUserPassword = async (username, newPassword) => {
   const res = await axios.put(URL_USER_SVC, { username, newPassword })
   console.log(res)
   return res
+}
+
+//--------Private utils----------//
+const getJWT = () => {
+  const token = Cookies.get(COOKIES_AUTH_TOKEN)
+  if (!token) {
+    throw new Error('JWT not found in cookies.')
+  }
+  return token
 }

--- a/frontend/src/api/userService.js
+++ b/frontend/src/api/userService.js
@@ -1,6 +1,10 @@
 import axios from 'axios'
 import Cookies from 'js-cookie'
-import { URL_USER_SVC, URL_USER_LOGIN_SVC } from '../utils/configs'
+import {
+  URL_USER_SVC,
+  URL_USER_LOGIN_SVC,
+  URL_USER_LOGOUT_SVC,
+} from '../utils/configs'
 import {
   STATUS_CODE_SUCCESS,
   COOKIES_AUTH_TOKEN,
@@ -11,6 +15,19 @@ export const loginUser = async (username, password) => {
   const res = await axios.post(URL_USER_LOGIN_SVC, { username, password })
   if (res?.status === STATUS_CODE_SUCCESS) {
     Cookies.set(COOKIES_AUTH_TOKEN, res.data.token, { expires: JWT_EXPIRY })
+  }
+  return res
+}
+
+export const logoutUser = async () => {
+  const token = Cookies.get(COOKIES_AUTH_TOKEN)
+  if (!token) {
+    throw new Error('JWT not found in cookies.')
+  }
+
+  const res = await axios.post(URL_USER_LOGOUT_SVC, { token })
+  if (res?.status === STATUS_CODE_SUCCESS) {
+    Cookies.remove(COOKIES_AUTH_TOKEN)
   }
   return res
 }

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -8,6 +8,7 @@ import AccountCircle from '@mui/icons-material/AccountCircle'
 import MenuItem from '@mui/material/MenuItem'
 import Menu from '@mui/material/Menu'
 import { logoutUser } from '../api/userService'
+import { loginUrl } from '../utils/routeConstants'
 
 const NavBar = () => {
   const [anchorEl, setAnchorEl] = useState(null)
@@ -25,7 +26,7 @@ const NavBar = () => {
     try {
       await logoutUser()
       handleClose()
-      navigate('./login', { replace: true })
+      navigate(loginUrl, { replace: true })
     } catch (err) {
       console.error(`Failed to log user out: ${err}`)
     }

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -1,0 +1,69 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import AppBar from '@mui/material/AppBar'
+import Toolbar from '@mui/material/Toolbar'
+import Typography from '@mui/material/Typography'
+import IconButton from '@mui/material/IconButton'
+import AccountCircle from '@mui/icons-material/AccountCircle'
+import MenuItem from '@mui/material/MenuItem'
+import Menu from '@mui/material/Menu'
+import { logoutUser } from '../api/userService'
+
+const NavBar = () => {
+  const [anchorEl, setAnchorEl] = useState(null)
+  const navigate = useNavigate()
+
+  const handleMenu = (event) => {
+    setAnchorEl(event.currentTarget)
+  }
+
+  const handleClose = () => {
+    setAnchorEl(null)
+  }
+
+  const handleLogout = async () => {
+    try {
+      await logoutUser()
+      handleClose()
+      navigate('./login', { replace: true })
+    } catch (err) {
+      console.error(`Failed to log user out: ${err}`)
+    }
+  }
+
+  return (
+    <AppBar position="static">
+      <Toolbar>
+        <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+          PeerPrep
+        </Typography>
+        <div>
+          <IconButton size="large" onClick={handleMenu} color="inherit">
+            <AccountCircle />
+          </IconButton>
+          {/* TODO: Only show the 'account' icon when user is logged in.
+              To be done when we add auth checks to private pages.*/}
+          <Menu
+            id="menu-appbar"
+            anchorEl={anchorEl}
+            anchorOrigin={{
+              vertical: 'top',
+              horizontal: 'right',
+            }}
+            keepMounted
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'right',
+            }}
+            open={!!anchorEl}
+            onClose={handleClose}
+          >
+            <MenuItem onClick={handleLogout}>Log out</MenuItem>
+          </Menu>
+        </div>
+      </Toolbar>
+    </AppBar>
+  )
+}
+
+export default NavBar

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+body {
+  margin: 0
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
+import './index.css'
 
 const root = ReactDOM.createRoot(document.getElementById('root'))
 root.render(<App />)

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -1,7 +1,8 @@
 import { Box, Button, TextField, Typography } from '@mui/material'
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { changeUserPassword } from '../api/userService'
+import { changeUserPassword, deleteUser } from '../api/userService'
+import { homeUrl, baseUrl } from '../utils/routeConstants'
 
 const ProfilePage = () => {
   const [newPassword, setNewPassword] = useState('')
@@ -24,6 +25,17 @@ const ProfilePage = () => {
       console.log('success ', res)
     } catch (err) {
       console.log('error: ', err)
+    }
+  }
+
+  // hardcoded for now also. Will read this from context next time.
+  const username = 'samtest10'
+  const handleDeleteAccount = async () => {
+    try {
+      await deleteUser(username)
+      navigate(baseUrl)
+    } catch (err) {
+      console.log(`Failed to delete user account: ${err}`)
     }
   }
 
@@ -68,7 +80,15 @@ const ProfilePage = () => {
         <Button
           sx={{ margin: '2px' }}
           variant={'outlined'}
-          onClick={() => navigate('/home')}
+          color={'error'}
+          onClick={handleDeleteAccount}
+        >
+          {'Delete Account'}
+        </Button>
+        <Button
+          sx={{ margin: '2px' }}
+          variant={'outlined'}
+          onClick={() => navigate(homeUrl)}
         >
           {'Back to Home'}
         </Button>

--- a/frontend/src/pages/SignupPage.js
+++ b/frontend/src/pages/SignupPage.js
@@ -1,10 +1,9 @@
 import { useState } from 'react'
-import axios from 'axios'
 import { Link } from 'react-router-dom'
 import { Button } from '@mui/material'
 import UserAuth from '../components/UserAuth'
+import { signupUser } from '../api/userService'
 import { STATUS_CODE_CONFLICT, STATUS_CODE_CREATED } from '../utils/constants'
-import { URL_USER_SVC } from '../utils/configs'
 import { checkFormFields } from '../utils/main'
 
 const SignupPage = () => {
@@ -16,18 +15,19 @@ const SignupPage = () => {
   const handleSignup = async (username, password) => {
     setIsSignupSuccess(false)
     checkFormFields(username, password, setErrorDialog)
-    const res = await axios
-      .post(URL_USER_SVC, { username, password })
-      .catch((err) => {
-        if (err.response.status === STATUS_CODE_CONFLICT) {
-          setErrorDialog('This username already exists')
-        } else {
-          setErrorDialog('Please try again later')
-        }
-      })
-    if (res && res.status === STATUS_CODE_CREATED) {
-      setSuccessDialog('Account successfully created')
-      setIsSignupSuccess(true)
+
+    try {
+      const res = await signupUser(username, password)
+      if (res && res.status === STATUS_CODE_CREATED) {
+        setSuccessDialog('Account successfully created')
+        setIsSignupSuccess(true)
+      }
+    } catch (err) {
+      if (err.response.status === STATUS_CODE_CONFLICT) {
+        setErrorDialog('This username already exists')
+      } else {
+        setErrorDialog('Please try again later')
+      }
     }
   }
 

--- a/frontend/src/utils/configs.js
+++ b/frontend/src/utils/configs.js
@@ -5,3 +5,4 @@ const PREFIX_USER_SVC = '/api/user'
 
 export const URL_USER_SVC = URI_USER_SVC + PREFIX_USER_SVC
 export const URL_USER_LOGIN_SVC = `${URL_USER_SVC}/login`
+export const URL_USER_LOGOUT_SVC = `${URL_USER_SVC}/logout`

--- a/frontend/src/utils/routeConstants.js
+++ b/frontend/src/utils/routeConstants.js
@@ -1,0 +1,5 @@
+export const baseUrl = '/'
+export const homeUrl = `${baseUrl}home`
+export const signupUrl = `${baseUrl}signup`
+export const loginUrl = `${baseUrl}login`
+export const profileUrl = `${baseUrl}profile`


### PR DESCRIPTION
FR 1.4: Allow users to log out of their account
- Added a navbar to our site which has an account icon/menu that contains a log out button.
- Upon successfully invalidating the user's JWT on the backend, the frontend will also delete the JWT cookie.
- Users are then redirected to `/login` after the whole logout flow completes.

FR 1.5: Allow users to delete their accounts
- Added a 'delete account' button to the profile page
- Users are redirected to `/` after their accounts are deleted.

Other stuff:
- Extracted our route constants to `routeConstants.js`
- Added the user signup wrapper method as discussed before