### PR TITLE
FR 1.7 v2: moar auth stuff

### DIFF
--- a/frontend/src/api/userService.js
+++ b/frontend/src/api/userService.js
@@ -11,6 +11,12 @@ import {
   JWT_EXPIRY,
 } from '../utils/constants'
 
+export const getUser = async () => {
+  return axios.get(URL_USER_SVC, {
+    ...getAuthHeader(),
+  })
+}
+
 export const loginUser = async (username, password) => {
   const res = await axios.post(URL_USER_LOGIN_SVC, { username, password })
   if (res?.status === STATUS_CODE_SUCCESS) {

--- a/frontend/src/components/ChangePasswordDialog.js
+++ b/frontend/src/components/ChangePasswordDialog.js
@@ -1,43 +1,41 @@
-import { useState } from 'react'
+import { useState, useContext } from 'react'
 import {
-    Button,
-    Dialog,
-    DialogActions,
-    DialogContent,
-    DialogContentText,
-    DialogTitle,
-    TextField
-  } from '@mui/material'
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  TextField,
+} from '@mui/material'
+import { UserContext } from '../contexts/UserContext'
 import { changeUserPassword } from '../api/userService'
-  
-const ChangePasswordDialog = ({ isDialogOpen, handleCloseDialog}) => {
+
+const ChangePasswordDialog = ({ isDialogOpen, handleCloseDialog }) => {
   const [newPassword, setNewPassword] = useState('')
-  const [newPasswordTextFieldChanged, setNewPasswordTextFieldChanged] = useState(false)
+  const [newPasswordTextFieldChanged, setNewPasswordTextFieldChanged] =
+    useState(false)
+  const user = useContext(UserContext)
 
   const handleCancel = () => {
-    setNewPassword('');
-    setNewPasswordTextFieldChanged(false);
-    handleCloseDialog();
+    setNewPassword('')
+    setNewPasswordTextFieldChanged(false)
+    handleCloseDialog()
   }
-
-  // Hardcoded value for now, for those doing cookies/ jwt/ context
-  // need to read from there.
-  // To test, check atlas to see if there are changes to the hash.
-  const uuid = '631ad96284e0659e96e66c89'
 
   const handleChangePassword = async () => {
     if (!newPassword) {
-      console.log('Password cannot be empty!')  
-      setNewPassword('');
-      setNewPasswordTextFieldChanged(true);
+      console.log('Password cannot be empty!')
+      setNewPassword('')
+      setNewPasswordTextFieldChanged(true)
       return
     }
 
     try {
-      const res = await changeUserPassword(uuid, newPassword)
+      const res = await changeUserPassword(user._id, newPassword)
       console.log('success ', res)
-      setNewPassword('');
-      setNewPasswordTextFieldChanged(false);
+      setNewPassword('')
+      setNewPasswordTextFieldChanged(false)
       handleCloseDialog()
     } catch (err) {
       console.log('error: ', err)
@@ -51,50 +49,50 @@ const ChangePasswordDialog = ({ isDialogOpen, handleCloseDialog}) => {
         <DialogContentText>
           Please enter your new password below and submit.
         </DialogContentText>
-        {(!newPassword && !newPasswordTextFieldChanged) && (
+        {!newPassword && !newPasswordTextFieldChanged && (
           <div>
-              <TextField
-                autoFocus
-                fullWidth
-                margin="normal"
-                label="New Password"
-                type="password"
-                variant="standard"
-                value={newPassword}
-                onChange={(e) => {
-                  setNewPasswordTextFieldChanged(true);
-                  setNewPassword(e.target.value)
-                }}
-              />
+            <TextField
+              autoFocus
+              fullWidth
+              margin="normal"
+              label="New Password"
+              type="password"
+              variant="standard"
+              value={newPassword}
+              onChange={(e) => {
+                setNewPasswordTextFieldChanged(true)
+                setNewPassword(e.target.value)
+              }}
+            />
           </div>
         )}
-        {(newPassword && newPasswordTextFieldChanged) && (
+        {newPassword && newPasswordTextFieldChanged && (
           <div>
-              <TextField
-                autoFocus
-                fullWidth
-                margin="normal"
-                label="New Password"
-                type="password"
-                variant="standard"
-                value={newPassword}
-                onChange={(e) => setNewPassword(e.target.value)}
-              />
+            <TextField
+              autoFocus
+              fullWidth
+              margin="normal"
+              label="New Password"
+              type="password"
+              variant="standard"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+            />
           </div>
         )}
-        {(!newPassword && newPasswordTextFieldChanged) && (
+        {!newPassword && newPasswordTextFieldChanged && (
           <div>
-              <TextField
-                autoFocus
-                error
-                fullWidth
-                margin="normal"
-                label="New Password"
-                helperText="New password cannot be empty"
-                variant="standard"
-                value={newPassword}
-                onChange={(e) => setNewPassword(e.target.value)}
-              />
+            <TextField
+              autoFocus
+              error
+              fullWidth
+              margin="normal"
+              label="New Password"
+              helperText="New password cannot be empty"
+              variant="standard"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+            />
           </div>
         )}
       </DialogContent>
@@ -107,4 +105,3 @@ const ChangePasswordDialog = ({ isDialogOpen, handleCloseDialog}) => {
 }
 
 export default ChangePasswordDialog
-  

--- a/frontend/src/components/DeleteAccountDialog.js
+++ b/frontend/src/components/DeleteAccountDialog.js
@@ -1,23 +1,24 @@
+import { useContext } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
-    Button,
-    Dialog,
-    DialogActions,
-    DialogContent,
-    DialogContentText,
-    DialogTitle
-  } from '@mui/material'
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@mui/material'
+import { UserContext } from '../contexts/UserContext'
 import { deleteUser } from '../api/userService'
 import { baseUrl } from '../utils/routeConstants'
-  
+
 const DeleteAccountDialog = ({ isDialogOpen, handleNo }) => {
   const navigate = useNavigate()
+  const user = useContext(UserContext)
 
-  // Hardcoded for now also. Will read this from context next time.
-  const username = 'samtest10'
   const handleDeleteAccount = async () => {
     try {
-      await deleteUser(username)
+      await deleteUser(user.username)
       navigate(baseUrl)
     } catch (err) {
       console.log(`Failed to delete user account: ${err}`)

--- a/frontend/src/components/PrivateRoute.js
+++ b/frontend/src/components/PrivateRoute.js
@@ -1,19 +1,76 @@
+import { useState, useEffect } from 'react'
 import { Navigate, useLocation } from 'react-router-dom'
-import { isUserLoggedIn } from '../api/userService'
+import Cookies from 'js-cookie'
+import CircularProgress from '@mui/material/CircularProgress'
+import Box from '@mui/material/Box'
+import { isUserLoggedIn, getUser } from '../api/userService'
 import { loginUrl } from '../utils/routeConstants'
-import { AUTH_REDIRECT } from '../utils/constants'
+import { AUTH_REDIRECT, COOKIES_AUTH_TOKEN } from '../utils/constants'
+
+// enum for the different view states in an FSM-pattern
+const PrivateRouteViewState = {
+  loading: 'LOADING',
+  authed: 'AUTHED',
+  unauthed: 'UNAUTHED',
+}
 
 const PrivateRoute = ({ children }) => {
+  const [viewState, setViewState] = useState(PrivateRouteViewState.loading)
   const location = useLocation()
 
-  if (!isUserLoggedIn()) {
+  useEffect(() => {
+    setViewState(PrivateRouteViewState.loading)
+
+    const authCheck = async () => {
+      if (!isUserLoggedIn()) {
+        setViewState(PrivateRouteViewState.unauthed)
+        return
+      }
+
+      try {
+        const response = await getUser()
+        setViewState(PrivateRouteViewState.authed)
+      } catch (err) {
+        // JWT possibly expired or invalid
+        console.error('Error initializaing app', err)
+        setViewState(PrivateRouteViewState.unauthed)
+      }
+    }
+
+    // set a delay so that the loading state lasts at least 300ms.
+    // Otherwise, the loading spinner might flash for a very short time and cause flicker
+    setTimeout(authCheck, 300)
+  }, [location.pathname])
+
+  const _renderLoading = () => {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', paddingTop: '5%' }}>
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  const _renderRedirect = () => {
     // Save the url of the current page before redirecting the user to log in.
     // Allows us to bring the user back to the page he/she was trying to access after logging in.
     window.localStorage.setItem(AUTH_REDIRECT, location.pathname)
+    Cookies.remove(COOKIES_AUTH_TOKEN)
     return <Navigate to={loginUrl} replace={true} />
   }
 
-  return children
+  switch (viewState) {
+    case PrivateRouteViewState.loading:
+      return _renderLoading()
+
+    case PrivateRouteViewState.unauthed:
+      return _renderRedirect()
+
+    case PrivateRouteViewState.authed:
+      return children
+
+    default:
+      return null
+  }
 }
 
 export default PrivateRoute

--- a/frontend/src/components/PrivateRoute.js
+++ b/frontend/src/components/PrivateRoute.js
@@ -3,6 +3,7 @@ import { Navigate, useLocation } from 'react-router-dom'
 import Cookies from 'js-cookie'
 import CircularProgress from '@mui/material/CircularProgress'
 import Box from '@mui/material/Box'
+import { UserContext } from '../contexts/UserContext'
 import { isUserLoggedIn, getUser } from '../api/userService'
 import { loginUrl } from '../utils/routeConstants'
 import { AUTH_REDIRECT, COOKIES_AUTH_TOKEN } from '../utils/constants'
@@ -16,6 +17,7 @@ const PrivateRouteViewState = {
 
 const PrivateRoute = ({ children }) => {
   const [viewState, setViewState] = useState(PrivateRouteViewState.loading)
+  const [user, setUser] = useState({})
   const location = useLocation()
 
   useEffect(() => {
@@ -29,6 +31,7 @@ const PrivateRoute = ({ children }) => {
 
       try {
         const response = await getUser()
+        setUser(response.data)
         setViewState(PrivateRouteViewState.authed)
       } catch (err) {
         // JWT possibly expired or invalid
@@ -66,7 +69,9 @@ const PrivateRoute = ({ children }) => {
       return _renderRedirect()
 
     case PrivateRouteViewState.authed:
-      return children
+      return (
+        <UserContext.Provider value={user}>{children}</UserContext.Provider>
+      )
 
     default:
       return null

--- a/frontend/src/contexts/UserContext.js
+++ b/frontend/src/contexts/UserContext.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react'
+
+export const UserContext = createContext({
+  user: {},
+})

--- a/user-service/constants.js
+++ b/user-service/constants.js
@@ -1,2 +1,2 @@
 export const REDIS_JWT_KEY = 'invalid_jwt'
-export const JWT_EXPIRY = 7 * 24 * 60 * 60 // 7 days in seconds
+export const JWT_EXPIRY = 15 * 60 // 15 mins in seconds

--- a/user-service/controller/user-controller.js
+++ b/user-service/controller/user-controller.js
@@ -5,11 +5,23 @@ import {
   ormCheckIfUserExists as _checkIfUserExists,
   ormUpdateUserPassword as _updateUserPassword,
   ormInvalidateJWT as _invalidateJWT,
+  ormFindUserById as _findUserById,
 } from '../model/user-orm.js'
 import { JWT_EXPIRY } from '../constants.js'
 import jwt from 'jsonwebtoken'
 import bcrypt from 'bcrypt'
 import 'dotenv/config'
+
+export const getUser = async (req, res) => {
+  const { userId } = req
+
+  const user = await _findUserById(userId, { password: 0 })
+  if (user.err) {
+    return res.status(500).json({ message: 'Error retrieving user.' })
+  }
+
+  return res.status(200).json(user)
+}
 
 export const createUser = async (req, res) => {
   try {
@@ -74,9 +86,13 @@ export const loginUser = async (req, res) => {
     return res.status(500).json({ message: 'ERROR: Could not log user in' })
   }
   if (user && (await bcrypt.compare(password, user.password))) {
-    const token = jwt.sign({ username, password }, process.env.TOKEN_SECRET, {
-      expiresIn: JWT_EXPIRY,
-    })
+    const token = jwt.sign(
+      { userId: user._id.toString(), password },
+      process.env.TOKEN_SECRET,
+      {
+        expiresIn: JWT_EXPIRY,
+      }
+    )
     return res.status(200).json({ userId: user._id, token })
   }
   return res.status(401).send('Invalid login credentials')

--- a/user-service/index.js
+++ b/user-service/index.js
@@ -8,6 +8,7 @@ app.use(express.json())
 app.use(cors()) // config cors so that front-end can use
 app.options('*', cors())
 import {
+  getUser,
   createUser,
   loginUser,
   logoutUser,
@@ -18,7 +19,7 @@ import {
 const router = express.Router()
 
 // Controller will contain all the User-defined Routes
-router.get('/', (_, res) => res.send('Hello World from user-service'))
+router.get('/', authenticateToken, getUser)
 router.post('/', createUser)
 router.put('/', authenticateToken, updateUserPassword)
 router.delete('/', authenticateToken, deleteUser)

--- a/user-service/middleware/auth.js
+++ b/user-service/middleware/auth.js
@@ -13,10 +13,11 @@ const authenticateToken = async (req, res, next) => {
     return res.sendStatus(403)
   }
 
-  jwt.verify(token, process.env.TOKEN_SECRET, (err, _) => {
+  jwt.verify(token, process.env.TOKEN_SECRET, (err, user) => {
     if (err) {
       return res.sendStatus(403)
     } else {
+      req.userId = user.userId
       req.token = token
       next()
     }

--- a/user-service/model/repository.js
+++ b/user-service/model/repository.js
@@ -18,8 +18,8 @@ export const createUser = async (params) => {
   return new UserModel(params)
 }
 
-export const findUser = async (query) => {
-  return UserModel.findOne(query)
+export const findUser = async (query, projection) => {
+  return UserModel.findOne(query, projection)
 }
 
 export const checkIfUserExists = async (query) => {

--- a/user-service/model/user-orm.js
+++ b/user-service/model/user-orm.js
@@ -31,6 +31,15 @@ export const ormDeleteUser = async (username) => {
   }
 }
 
+export const ormFindUserById = async (id, projection) => {
+  try {
+    return await findUser({ _id: id }, projection)
+  } catch (err) {
+    console.log('ERROR: Could not query for user')
+    return { err }
+  }
+}
+
 export const ormFindUserByUsername = async (username) => {
   try {
     return await findUser({ username })


### PR DESCRIPTION
### Backend
- Added `GET /api/user` route to retrieve a user's info. This route is protected.
- Decreased JWT lifespan from 7 days to 15mins. I'll tackle refresh tokens next time... it seems like a non-core feature thooo
- Also changed our JWTs to hold user ids instead of usernames. I think we should use user ids to identify users instead of their username moving forward...?
### Frontend
- Every time a user visits a `PrivateRoute`, the component makes a call to the endpoint above, which acts as a check to see if the client's JWT has expired or not. To test, you can change the JWT expiry in user-service to be 1 min or something, then log in on the frontend. After 1 minute, refreshing the page or navigating to another protected page should trigger a check and force you to log in again.
- Added a user context object
- Hooked up account deletion and password changing to use the actual user's id/username
- Also had a bunch of automatic code-format changes - @dannytayjy You can install Prettier so that your vscode auto-formats according to the rules @RyanCheungJF set up!