### PR TITLE
FR 1.5 & 1.6 Frontend Enhancement (Continuation - Part 2)

### DIFF
--- a/frontend/src/components/ChangePasswordDialog.js
+++ b/frontend/src/components/ChangePasswordDialog.js
@@ -8,14 +8,24 @@ import {
   DialogTitle,
   TextField,
 } from '@mui/material'
-import { UserContext } from '../contexts/UserContext'
 import { changeUserPassword } from '../api/userService'
+import { UserContext } from '../contexts/UserContext'
+import SnackbarAlert from './SnackbarAlert'
 
 const ChangePasswordDialog = ({ dialogOpen, handleCloseDialog }) => {
   const [newPassword, setNewPassword] = useState('')
   const [newPasswordTextFieldChanged, setNewPasswordTextFieldChanged] =
     useState(false)
+
   const user = useContext(UserContext)
+
+  // Change Password Successful Alert
+  const [
+    changePasswordSuccessfulAlertOpen,
+    setChangePasswordSuccessfulAlertOpen,
+  ] = useState(false)
+  const handleChangePasswordSuccessfulOpenAlert = () =>
+    setChangePasswordSuccessfulAlertOpen(true)
 
   const handleCancel = () => {
     setNewPassword('')
@@ -37,64 +47,76 @@ const ChangePasswordDialog = ({ dialogOpen, handleCloseDialog }) => {
       setNewPassword('')
       setNewPasswordTextFieldChanged(false)
       handleCloseDialog()
+      handleChangePasswordSuccessfulOpenAlert()
     } catch (err) {
       console.log('error: ', err)
     }
   }
 
   return (
-    <Dialog fullWidth={true} maxWidth="sm" open={dialogOpen}>
-      <DialogTitle>Change Password</DialogTitle>
-      <DialogContent dividers>
-        <DialogContentText>
-          Please enter your new password below and submit.
-        </DialogContentText>
-        {!newPassword && !newPasswordTextFieldChanged && (
-          <TextField
-            autoFocus
-            fullWidth
-            margin="normal"
-            label="New Password"
-            type="password"
-            variant="standard"
-            value={newPassword}
-            onChange={(e) => {
-              setNewPasswordTextFieldChanged(true)
-              setNewPassword(e.target.value)
-            }}
-          />
-        )}
-        {newPassword && newPasswordTextFieldChanged && (
-          <TextField
-            autoFocus
-            fullWidth
-            margin="normal"
-            label="New Password"
-            type="password"
-            variant="standard"
-            value={newPassword}
-            onChange={(e) => setNewPassword(e.target.value)}
-          />
-        )}
-        {!newPassword && newPasswordTextFieldChanged && (
-          <TextField
-            autoFocus
-            error
-            fullWidth
-            margin="normal"
-            label="New Password"
-            helperText="New password cannot be empty"
-            variant="standard"
-            value={newPassword}
-            onChange={(e) => setNewPassword(e.target.value)}
-          />
-        )}
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={handleCancel}>Cancel</Button>
-        <Button onClick={handleChangePassword}>Submit</Button>
-      </DialogActions>
-    </Dialog>
+    <>
+      <div>
+        <Dialog fullWidth={true} maxWidth="sm" open={dialogOpen}>
+          <DialogTitle>Change Password</DialogTitle>
+          <DialogContent dividers>
+            <DialogContentText>
+              Please enter your new password below and submit.
+            </DialogContentText>
+            {!newPassword && !newPasswordTextFieldChanged && (
+              <TextField
+                autoFocus
+                fullWidth
+                margin="normal"
+                label="New Password"
+                type="password"
+                variant="standard"
+                value={newPassword}
+                onChange={(e) => {
+                  setNewPasswordTextFieldChanged(true)
+                  setNewPassword(e.target.value)
+                }}
+              />
+            )}
+            {newPassword && newPasswordTextFieldChanged && (
+              <TextField
+                autoFocus
+                fullWidth
+                margin="normal"
+                label="New Password"
+                type="password"
+                variant="standard"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+              />
+            )}
+            {!newPassword && newPasswordTextFieldChanged && (
+              <TextField
+                autoFocus
+                error
+                fullWidth
+                margin="normal"
+                label="New Password"
+                helperText="New password cannot be empty"
+                variant="standard"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+              />
+            )}
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleCancel}>Cancel</Button>
+            <Button onClick={handleChangePassword}>Submit</Button>
+          </DialogActions>
+        </Dialog>
+      </div>
+
+      <SnackbarAlert
+        alertOpen={changePasswordSuccessfulAlertOpen}
+        setAlertOpen={setChangePasswordSuccessfulAlertOpen}
+        severity="success"
+        alertMsg="Your password has been changed successfully!"
+      />
+    </>
   )
 }
 

--- a/frontend/src/components/DeleteAccountDialog.js
+++ b/frontend/src/components/DeleteAccountDialog.js
@@ -1,4 +1,4 @@
-import { useContext } from 'react'
+import { useState, useContext } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
   Button,
@@ -8,36 +8,61 @@ import {
   DialogContentText,
   DialogTitle,
 } from '@mui/material'
-import { UserContext } from '../contexts/UserContext'
 import { deleteUser } from '../api/userService'
+import { UserContext } from '../contexts/UserContext'
 import { baseUrl } from '../utils/routeConstants'
+import SnackbarAlert from './SnackbarAlert'
 
 const DeleteAccountDialog = ({ dialogOpen, handleNo }) => {
-  const navigate = useNavigate()
   const user = useContext(UserContext)
+  const navigate = useNavigate()
+
+  // Delete Account Successful Alert
+  const [
+    deleteAccountSuccessfulAlertOpen,
+    setDeleteAccountSuccessfulAlertOpen,
+  ] = useState(false)
+  const handleDeleteAccountSuccessfulOpenAlert = () =>
+    setDeleteAccountSuccessfulAlertOpen(true)
 
   const handleDeleteAccount = async () => {
     try {
       await deleteUser(user.username)
       navigate(baseUrl)
+
+      // The alert will not show as the parent component (ProfilePage)
+      // is killed after navigating to baseUrl. Need to think and discuss
+      // a workaround for this.
+      handleDeleteAccountSuccessfulOpenAlert()
     } catch (err) {
       console.log(`Failed to delete user account: ${err}`)
     }
   }
 
   return (
-    <Dialog open={dialogOpen}>
-      <DialogTitle>Delete Account</DialogTitle>
-      <DialogContent dividers>
-        <DialogContentText>
-          Are you sure you want to delete your account?
-        </DialogContentText>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={handleNo}>No</Button>
-        <Button onClick={handleDeleteAccount}>Yes</Button>
-      </DialogActions>
-    </Dialog>
+    <>
+      <div>
+        <Dialog open={dialogOpen}>
+          <DialogTitle>Delete Account</DialogTitle>
+          <DialogContent dividers>
+            <DialogContentText>
+              Are you sure you want to delete your account?
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleNo}>No</Button>
+            <Button onClick={handleDeleteAccount}>Yes</Button>
+          </DialogActions>
+        </Dialog>
+      </div>
+
+      <SnackbarAlert
+        alertOpen={deleteAccountSuccessfulAlertOpen}
+        setAlertOpen={setDeleteAccountSuccessfulAlertOpen}
+        severity="success"
+        alertMsg="Your account has been deleted successfully!"
+      />
+    </>
   )
 }
 

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -1,12 +1,12 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import AccountCircle from '@mui/icons-material/AccountCircle'
 import AppBar from '@mui/material/AppBar'
+import IconButton from '@mui/material/IconButton'
+import Menu from '@mui/material/Menu'
+import MenuItem from '@mui/material/MenuItem'
 import Toolbar from '@mui/material/Toolbar'
 import Typography from '@mui/material/Typography'
-import IconButton from '@mui/material/IconButton'
-import AccountCircle from '@mui/icons-material/AccountCircle'
-import MenuItem from '@mui/material/MenuItem'
-import Menu from '@mui/material/Menu'
 import { logoutUser, isUserLoggedIn } from '../api/userService'
 import { loginUrl, profileUrl } from '../utils/routeConstants'
 
@@ -23,7 +23,7 @@ const NavBar = () => {
   }
 
   const handleProfile = () => {
-    handleClose();
+    handleClose()
     navigate(profileUrl)
   }
 

--- a/frontend/src/components/PrivateRoute.js
+++ b/frontend/src/components/PrivateRoute.js
@@ -1,12 +1,12 @@
 import { useState, useEffect } from 'react'
 import { Navigate, useLocation } from 'react-router-dom'
 import Cookies from 'js-cookie'
-import CircularProgress from '@mui/material/CircularProgress'
 import Box from '@mui/material/Box'
-import { UserContext } from '../contexts/UserContext'
+import CircularProgress from '@mui/material/CircularProgress'
 import { isUserLoggedIn, getUser } from '../api/userService'
-import { loginUrl } from '../utils/routeConstants'
+import { UserContext } from '../contexts/UserContext'
 import { AUTH_REDIRECT, COOKIES_AUTH_TOKEN } from '../utils/constants'
+import { loginUrl } from '../utils/routeConstants'
 
 // enum for the different view states in an FSM-pattern
 const PrivateRouteViewState = {

--- a/frontend/src/components/SnackbarAlert.js
+++ b/frontend/src/components/SnackbarAlert.js
@@ -1,0 +1,37 @@
+import React, { forwardRef } from 'react'
+import MuiAlert from '@mui/material/Alert'
+import Snackbar from '@mui/material/Snackbar'
+
+const Alert = forwardRef(function Alert(props, ref) {
+  return <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />
+})
+
+const SnackbarAlert = ({
+  alertOpen,
+  setAlertOpen,
+  severity, // values for the respective alert design: error, warning, info, success
+  alertMsg,
+}) => {
+  const handleClose = (event, reason) => {
+    if (reason === 'clickaway') {
+      return
+    }
+
+    setAlertOpen(false)
+  }
+
+  return (
+    <Snackbar
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      open={alertOpen}
+      autoHideDuration={6000}
+      onClose={handleClose}
+    >
+      <Alert onClose={handleClose} severity={severity} sx={{ width: '100%' }}>
+        {alertMsg}
+      </Alert>
+    </Snackbar>
+  )
+}
+
+export default SnackbarAlert

--- a/frontend/src/components/TransitionAlert.js
+++ b/frontend/src/components/TransitionAlert.js
@@ -1,0 +1,40 @@
+import Alert from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import CloseIcon from '@mui/icons-material/Close'
+import Collapse from '@mui/material/Collapse'
+import IconButton from '@mui/material/IconButton'
+
+const TransitionAlert = ({
+  alertOpen,
+  setAlertOpen,
+  severity, // values for the respective alert design: error, warning, info, success
+  alertMsg,
+}) => {
+  return (
+    <Box sx={{ width: '100%' }}>
+      <Collapse in={alertOpen}>
+        <Alert
+          variant="filled"
+          severity={severity}
+          action={
+            <IconButton
+              aria-label="close"
+              color="inherit"
+              size="small"
+              onClick={() => {
+                setAlertOpen(false)
+              }}
+            >
+              <CloseIcon fontSize="inherit" />
+            </IconButton>
+          }
+          sx={{ mb: 2 }}
+        >
+          {alertMsg}
+        </Alert>
+      </Collapse>
+    </Box>
+  )
+}
+
+export default TransitionAlert

--- a/frontend/src/components/TransitionModal.js
+++ b/frontend/src/components/TransitionModal.js
@@ -1,0 +1,53 @@
+import Backdrop from '@mui/material/Backdrop'
+import Box from '@mui/material/Box'
+import Fade from '@mui/material/Fade'
+import Modal from '@mui/material/Modal'
+import Typography from '@mui/material/Typography'
+
+const style = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 400,
+  bgcolor: 'background.paper',
+  border: '2px solid #000',
+  boxShadow: 24,
+  p: 4,
+}
+
+const TransitionModal = ({
+  modalOpen,
+  handleCloseModal,
+  modalTitle,
+  modalDescription,
+}) => {
+  return (
+    <div>
+      <Modal
+        aria-labelledby="transition-modal-title"
+        aria-describedby="transition-modal-description"
+        open={modalOpen}
+        onClose={handleCloseModal}
+        closeAfterTransition
+        BackdropComponent={Backdrop}
+        BackdropProps={{
+          timeout: 500,
+        }}
+      >
+        <Fade in={modalOpen}>
+          <Box sx={style}>
+            <Typography id="transition-modal-title" variant="h6" component="h2">
+              {modalTitle}
+            </Typography>
+            <Typography id="transition-modal-description" sx={{ mt: 2 }}>
+              {modalDescription}
+            </Typography>
+          </Box>
+        </Fade>
+      </Modal>
+    </div>
+  )
+}
+
+export default TransitionModal

--- a/frontend/src/components/UserAuth.js
+++ b/frontend/src/components/UserAuth.js
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import {
   Box,
   Button,
@@ -9,8 +11,6 @@ import {
   TextField,
   Typography,
 } from '@mui/material'
-import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
 
 const UserAuth = ({
   pageTitle,
@@ -93,7 +93,7 @@ const UserAuth = ({
           {isAuthSuccess ? (
             redirectButton()
           ) : (
-            <Button onClick={closeDialog}>Done</Button>
+            <Button onClick={closeDialog}>OK</Button>
           )}
         </DialogActions>
       </Dialog>

--- a/frontend/src/pages/LandingPage.js
+++ b/frontend/src/pages/LandingPage.js
@@ -1,5 +1,5 @@
-import { Box, Button, Typography } from '@mui/material'
 import { useNavigate, Navigate } from 'react-router-dom'
+import { Box, Button, Typography } from '@mui/material'
 import { isUserLoggedIn } from '../api/userService'
 import { homeUrl } from '../utils/routeConstants'
 

--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -1,16 +1,16 @@
 import { useState } from 'react'
 import { Link, Navigate } from 'react-router-dom'
 import { Button } from '@mui/material'
-import UserAuth from '../components/UserAuth'
+import { loginUser, isUserLoggedIn } from '../api/userService'
 import {
   AUTH_REDIRECT,
   STATUS_CODE_SUCCESS,
   STATUS_CODE_BAD_REQUEST,
   STATUS_CODE_UNAUTHORIZED,
 } from '../utils/constants'
-import { homeUrl } from '../utils/routeConstants'
 import { checkFormFields } from '../utils/main'
-import { loginUser, isUserLoggedIn } from '../api/userService'
+import { homeUrl } from '../utils/routeConstants'
+import UserAuth from '../components/UserAuth'
 
 const LoginPage = () => {
   const [isDialogOpen, setIsDialogOpen] = useState(false)
@@ -28,16 +28,16 @@ const LoginPage = () => {
     try {
       const res = await loginUser(username, password)
       if (res && res.status === STATUS_CODE_SUCCESS) {
-        setSuccessDialog('Logged in successfully!')
+        setSuccessDialog('Logged in successfully!') // not sure why success dialog is not showing
         setIsLoginSuccess(true)
       }
     } catch (err) {
       if (err.response.status === STATUS_CODE_UNAUTHORIZED) {
         setErrorDialog('Wrong username/password.')
       } else if (err.response.status === STATUS_CODE_BAD_REQUEST) {
-        setErrorDialog('Username and/or Password are missing!')
+        setErrorDialog('Username and/or Password are missing.')
       } else {
-        setErrorDialog('Please try again later')
+        setErrorDialog('Please try again later.')
       }
     }
   }

--- a/frontend/src/pages/MatchingPage.js
+++ b/frontend/src/pages/MatchingPage.js
@@ -1,5 +1,5 @@
 const MatchingPage = () => {
-    console.log('Welcome to matching page!')
+  console.log('Welcome to matching page!')
 }
 
 export default MatchingPage

--- a/frontend/src/pages/SignupPage.js
+++ b/frontend/src/pages/SignupPage.js
@@ -1,15 +1,15 @@
 import { useState } from 'react'
 import { Link, Navigate } from 'react-router-dom'
 import { Button } from '@mui/material'
-import UserAuth from '../components/UserAuth'
 import { signupUser, isUserLoggedIn } from '../api/userService'
 import {
   STATUS_CODE_CONFLICT,
   STATUS_CODE_BAD_REQUEST,
   STATUS_CODE_CREATED,
 } from '../utils/constants'
-import { homeUrl } from '../utils/routeConstants'
 import { checkFormFields } from '../utils/main'
+import { homeUrl } from '../utils/routeConstants'
+import UserAuth from '../components/UserAuth'
 
 const SignupPage = () => {
   const [isDialogOpen, setIsDialogOpen] = useState(false)
@@ -28,16 +28,16 @@ const SignupPage = () => {
     try {
       const res = await signupUser(username, password)
       if (res && res.status === STATUS_CODE_CREATED) {
-        setSuccessDialog('Account successfully created')
+        setSuccessDialog('Account successfully created!')
         setIsSignupSuccess(true)
       }
     } catch (err) {
       if (err.response.status === STATUS_CODE_CONFLICT) {
-        setErrorDialog('This username already exists')
+        setErrorDialog('This username already exists.')
       } else if (err.response.status === STATUS_CODE_BAD_REQUEST) {
-        setErrorDialog('Username and/or Password are missing!')
+        setErrorDialog('Username and/or Password are missing.')
       } else {
-        setErrorDialog('Please try again later')
+        setErrorDialog('Please try again later.')
       }
     }
   }


### PR DESCRIPTION
**Snackbar Alert for Change Password** (Commit: https://github.com/CS3219-AY2223S1/cs3219-project-ay2223s1-g35/pull/19/commits/5559912637482241f52a6b3bbb936305a2f9cea6)
- User can close the snackbar alert with the X button
- Snackbar alert will close on its own after 6 seconds.

![image](https://user-images.githubusercontent.com/6387754/192649879-04e9cbf2-d193-41ce-a1f5-26e8b5612fff.png)

**Snackbar Alert for Delete Account** (Commit: https://github.com/CS3219-AY2223S1/cs3219-project-ay2223s1-g35/pull/19/commits/2c9d88228b69ed93024b76c8addb839decc7674a)

![image](https://user-images.githubusercontent.com/6387754/192650010-28062f27-9b7b-446c-9498-88ba03d380a4.png)

Issue: 
- The alert will not show as the parent component (ProfilePage) is killed after navigating to baseUrl. Putting the alert before navigating to baseUrl will not work as navigation is almost instant. We need to think and discuss a workaround for this.
- One possible approach I can think of is to pass some props value (e.g. deleteAccountRedirection = true) to baseUrl (landing page) when we are navigating to baseUrl after an account is deleted. On the landing page, if deleteAccountRedirection = true, we will then show the snackbar alert (which means shifting the snackbar alert to landing page).

**Misc - Code Cleanup** (Commit: https://github.com/CS3219-AY2223S1/cs3219-project-ay2223s1-g35/pull/19/commits/8243a2b50cef8cf2bf44afa3fceae81b85a8feb7)
- Sort imports manually (I will look up some automated sorting tool to put inside our project and package.json soon)
- Standardise punctuation marks for dialog texts

**Misc - Components for Future Usage**
- Added TransitionModal component for future usage (Commit: https://github.com/CS3219-AY2223S1/cs3219-project-ay2223s1-g35/pull/19/commits/107db1dbf2191f55fddab526f9c03e6d1798c5f1)
- Added TransitionAlert component for future usage (Commit: https://github.com/CS3219-AY2223S1/cs3219-project-ay2223s1-g35/pull/19/commits/9f619b37dbaccaa34aa92f420ca28315d914ae98)

**Pending Issues**
- If the JWT expires, we should redirect them directly when the user clicks on the change password and delete account buttons.
- Also need to handle the scenario where the JWT expires when they are in the midst of the dialogs. This will be applicable to change password, delete account and finding match.