### PR TITLE
Auth fixes

### DIFF
--- a/frontend/src/components/PrivateRoute.js
+++ b/frontend/src/components/PrivateRoute.js
@@ -30,13 +30,13 @@ const PrivateRoute = ({ children }) => {
       }
 
       try {
+        // note that if getUser fails with 401 or 403, axios will redirect user to login too
         const response = await getUser()
         setUser(response.data)
         setViewState(PrivateRouteViewState.authed)
       } catch (err) {
         // JWT possibly expired or invalid
         console.error('Error initializaing app', err)
-        setViewState(PrivateRouteViewState.unauthed)
       }
     }
 

--- a/frontend/src/components/PrivateRoute.js
+++ b/frontend/src/components/PrivateRoute.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useLayoutEffect } from 'react'
 import { Navigate, useLocation } from 'react-router-dom'
 import Cookies from 'js-cookie'
 import CircularProgress from '@mui/material/CircularProgress'
@@ -20,7 +20,7 @@ const PrivateRoute = ({ children }) => {
   const [user, setUser] = useState({})
   const location = useLocation()
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setViewState(PrivateRouteViewState.loading)
 
     const authCheck = async () => {

--- a/frontend/src/pages/LandingPage.js
+++ b/frontend/src/pages/LandingPage.js
@@ -1,14 +1,17 @@
+import { useEffect } from 'react'
 import { Box, Button, Typography } from '@mui/material'
-import { useNavigate, Navigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import { isUserLoggedIn } from '../api/userService'
 import { homeUrl } from '../utils/routeConstants'
 
 const LandingPage = () => {
   const navigate = useNavigate()
 
-  if (isUserLoggedIn()) {
-    return <Navigate to={homeUrl} replace={true} />
-  }
+  useEffect(() => {
+    if (isUserLoggedIn()) {
+      navigate(homeUrl, { replace: true })
+    }
+  }, [navigate])
 
   return (
     <Box

--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { Link, Navigate } from 'react-router-dom'
+import { useState, useEffect } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
 import { Button } from '@mui/material'
 import UserAuth from '../components/UserAuth'
 import {
@@ -17,10 +17,13 @@ const LoginPage = () => {
   const [dialogTitle, setDialogTitle] = useState('')
   const [dialogMsg, setDialogMsg] = useState('')
   const [isLoginSuccess, setIsLoginSuccess] = useState(false)
+  const navigate = useNavigate()
 
-  if (isUserLoggedIn()) {
-    return <Navigate to={homeUrl} replace={true} />
-  }
+  useEffect(() => {
+    if (isUserLoggedIn()) {
+      navigate(homeUrl, { replace: true })
+    }
+  }, [navigate])
 
   const handleLogin = async (username, password) => {
     setIsLoginSuccess(false)
@@ -58,6 +61,8 @@ const LoginPage = () => {
 
   const redirectButton = () => {
     const redirectUrl = window.localStorage.getItem(AUTH_REDIRECT) ?? homeUrl
+    // reset the redirect url since it's only used this one time
+    window.localStorage.removeItem(AUTH_REDIRECT)
     return (
       <Button component={Link} to={redirectUrl} replace={true}>
         Close

--- a/frontend/src/pages/SignupPage.js
+++ b/frontend/src/pages/SignupPage.js
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { Link, Navigate } from 'react-router-dom'
+import { useState, useEffect } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
 import { Button } from '@mui/material'
 import UserAuth from '../components/UserAuth'
 import { signupUser, isUserLoggedIn } from '../api/userService'
@@ -16,10 +16,13 @@ const SignupPage = () => {
   const [dialogTitle, setDialogTitle] = useState('')
   const [dialogMsg, setDialogMsg] = useState('')
   const [isSignupSuccess, setIsSignupSuccess] = useState(false)
+  const navigate = useNavigate()
 
-  if (isUserLoggedIn()) {
-    return <Navigate to={homeUrl} replace={true} />
-  }
+  useEffect(() => {
+    if (isUserLoggedIn()) {
+      navigate(homeUrl, { replace: true })
+    }
+  }, [navigate])
 
   const handleSignup = async (username, password) => {
     setIsSignupSuccess(false)

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -3,6 +3,7 @@ export const STATUS_CODE_SUCCESS = 200
 export const STATUS_CODE_CREATED = 201
 export const STATUS_CODE_BAD_REQUEST = 400
 export const STATUS_CODE_UNAUTHORIZED = 401
+export const STATUS_CODE_FORBIDDEN = 403
 export const STATUS_CODE_CONFLICT = 409
 
 //------- AUTH CONSTANTS --------//


### PR DESCRIPTION
### Fixing auth checks in outgoing requests
As we found out recently, there was an edge case previously missed out in our auth checks: let's say you arrive on the profile page with a valid JWT. Because it's valid, our current auth check doesn't redirect you to login. Later on, you try to change your password, but your JWT is expired by then. The request is made and the backend returns a 401, but the client doesn't do anything. 

To fix this, I've created a custom axios instance with interceptors to handle authentication. Basically, we can use this instance to make requests to protected user-service endpoints in general and it'll do two things:
1. If the response is 401 or 403, the interceptor auto-redirects the user to log in. This solves the bug above and is a better solution than checking the user's JWT in React each time a page is mounted. 
2. Since we have this custom instance for auth checks, I've also added an interceptor to automatically add the auth header to outgoing requests so we don't need to manually type it for each request (change password, delete account, etc.)

More info here: https://axios-http.com/docs/interceptors

### Fixing the redirect problem (See @dannytayjy's tele message)
Expected behavior: When a user logs in, the login page should check if there's a redirect_url in localStorage and send him/her there if it exists. 

Bug now: User is always sent to homepage even when there's a redirect_url present

Why this is happening: The login page was calling `isUserLoggedIn()` on every render. If the user is logged in and tries to visit the login page, we redirect them to the homepage. This overrides the behavior we want in `redirectButton` since it runs the moment the user logs in and doesn't wait till the success modal opens.

Fix: `isUserLoggedIn()` should only be called on mount and not after every render, so I've wrapped it in a `useEffect` hook.

### Last tweak
Bug: I noticed that the profile page flickers when we navigate to it from the homepage.

Why: This is cos the auth check runs after the first render, so the user sees the profile page momentarily before we show the loading spinner (while performing the auth check), and then the profile page again after the check is done.

Fix: Use `useEffectLayout` hook instead of `useEffect` so that the check happens synchronously before the first paint to browser. 