### PR TITLE
Better collab partner checks

### DIFF
--- a/collaboration-service/controller/room-controller.js
+++ b/collaboration-service/controller/room-controller.js
@@ -36,8 +36,16 @@ export const deleteRoom = (_) => async (roomId) => {
   await _deleteRoom(roomId)
 }
 
-export const broadcastConnection = (socket) => async (roomId) => {
-  socket.to(roomId).emit('partner-connected')
+export const broadcastConnection = (io, socket) => async (roomId) => {
+  // get a list of clients in the socket.io room
+  const allSocketIORooms = io.sockets.adapter.rooms
+  const roomClients = allSocketIORooms.get(roomId)
+  const serializableClients = [...roomClients.keys()]
+
+  socket.to(roomId).emit('partner-connected', serializableClients)
+  // Also send to the socket that's just connected because it doesn't receive the room event above.
+  // I suspect socket.io just doesn't guarantee serial execution/protect against such race conditions
+  socket.emit('partner-connected', serializableClients)
 }
 
 export const broadcastDisconnection = (socket) => () => {

--- a/collaboration-service/index.js
+++ b/collaboration-service/index.js
@@ -22,7 +22,7 @@ io.on('connection', (socket) => {
     socket.join(roomId)
   })
   socket.on('join-room', getRoom(socket))
-  socket.on('join-room', broadcastConnection(socket))
+  socket.on('join-room', broadcastConnection(io, socket))
 
   socket.on('leave-room', deleteRoom(socket))
 

--- a/frontend/src/pages/CollaborationPage.js
+++ b/frontend/src/pages/CollaborationPage.js
@@ -42,8 +42,9 @@ const CollaborationPage = () => {
     collabSocket.on('partner-disconnected', () => {
       setIsPartnerOnline(false)
     })
-    collabSocket.on('partner-connected', () => {
-      setIsPartnerOnline(true)
+    collabSocket.on('partner-connected', (roomClients) => {
+      // check if user is the only one in the room or if there are more ppl
+      setIsPartnerOnline(roomClients.length > 1)
     })
   }, [])
 


### PR DESCRIPTION
Previously, we had a problematic scenario:
1. Let's say user A and user B are in a collab room
2. If user B disconnects, user A gets notified via a modal, which prevents him from interacting with the room (correct behavior)
3. If user A then refreshes the page, or leaves and comes back to the site, he/she gets put back into that room by matching service. However, user A is not notified that user B is still offline nor prevented from interacting with the room. (wrong behavior)

This PR fixes that issue. Every time a user joins a room, collab service will also return a list of clients in the room. The frontend can then determine if the user is alone in the room.

Here's a video to demonstrate that behavior:

https://user-images.githubusercontent.com/31149701/195493434-a13779e8-443a-4270-b16a-1d4fbb5bda01.mov



