### PR TITLE
Collaboration Page: Fix frontend bug + Sort codes for clarity

### DIFF
--- a/frontend/src/components/FindMatch.js
+++ b/frontend/src/components/FindMatch.js
@@ -22,7 +22,7 @@ const FindMatch = () => {
   const navigate = useNavigate()
 
   // Define finding match time out seconds
-  const findingMatchTimeOutSeconds = 30
+  const FINDING_MATCH_TIMEOUT_SEC = 30
 
   const [difficulty, setDifficulty] = useState('')
   const [room, setRoom] = useState()
@@ -111,7 +111,7 @@ const FindMatch = () => {
       <FindingMatchDialog
         dialogOpen={findingMatchDialogOpen}
         handleCloseDialog={handleFindingMatchCloseDialog}
-        findingMatchTimeOutSeconds={findingMatchTimeOutSeconds}
+        findingMatchTimeOutSeconds={FINDING_MATCH_TIMEOUT_SEC}
         startMatchingService={startMatchingService}
         stopMatchingService={stopMatchingService}
       />

--- a/frontend/src/components/FindMatch.js
+++ b/frontend/src/components/FindMatch.js
@@ -57,7 +57,11 @@ const FindMatch = () => {
     console.log('==> Start Matching Service')
     console.log('Difficulty: ' + difficulty)
 
+    console.log('========================================')
+    console.log('Matching Socket: ' + matchingSocket.id)
     const res = await findMatch(user._id, matchingSocket.id, difficulty)
+    console.log(res)
+    console.log('========================================')
 
     // Gets a response
     if (res) {
@@ -119,6 +123,8 @@ const FindMatch = () => {
   }
 
   matchingSocket.on('found-connection', (username, difficulty, qnsid) => {
+    console.log('========================================')
+    console.log('found-connection')
     const room = {
       room_id: username,
       id1: username,
@@ -127,6 +133,8 @@ const FindMatch = () => {
       difficulty: difficulty.toLowerCase(),
       datetime: new Date(),
     }
+    console.log(room)
+    console.log('========================================')
     setRoom(room)
   })
 

--- a/frontend/src/components/FindMatch.js
+++ b/frontend/src/components/FindMatch.js
@@ -57,11 +57,11 @@ const FindMatch = () => {
     console.log('==> Start Matching Service')
     console.log('Difficulty: ' + difficulty)
 
-    console.log('========================================')
-    console.log('Matching Socket: ' + matchingSocket.id)
+    // console.log('========================================')
+    // console.log('Matching Socket: ' + matchingSocket.id)
     const res = await findMatch(user._id, matchingSocket.id, difficulty)
-    console.log(res)
-    console.log('========================================')
+    // console.log(res)
+    // console.log('========================================')
 
     // Gets a response
     if (res) {
@@ -123,8 +123,8 @@ const FindMatch = () => {
   }
 
   matchingSocket.on('found-connection', (username, difficulty, qnsid) => {
-    console.log('========================================')
-    console.log('found-connection')
+    // console.log('========================================')
+    // console.log('found-connection')
     const room = {
       room_id: username,
       id1: username,
@@ -133,8 +133,8 @@ const FindMatch = () => {
       difficulty: difficulty.toLowerCase(),
       datetime: new Date(),
     }
-    console.log(room)
-    console.log('========================================')
+    // console.log(room)
+    // console.log('========================================')
     setRoom(room)
   })
 

--- a/frontend/src/components/ReviewPartnerDialog.js
+++ b/frontend/src/components/ReviewPartnerDialog.js
@@ -35,7 +35,7 @@ const ReviewPartnerDialog = ({
 
   const handleSkipReview = () => {
     handleCloseDialog()
-    navigate(homeUrl)
+    navigate(homeUrl, { replace: true })
   }
 
   const handleSubmitReview = async () => {
@@ -50,7 +50,7 @@ const ReviewPartnerDialog = ({
     await createReviewStats(partneruuid, user._id, FIELDS)
 
     handleCloseDialog()
-    navigate(homeUrl)
+    navigate(homeUrl, { replace: true })
   }
 
   return (

--- a/frontend/src/pages/CollaborationPage.js
+++ b/frontend/src/pages/CollaborationPage.js
@@ -188,14 +188,14 @@ const CollaborationPage = () => {
 
   useEffect(() => {}, [partneruuid])
 
-  useEffect(() => {
+  /* useEffect(() => {
     console.log('========================================')
     console.log('partneruuid: ' + partneruuid)
     console.log('1. isOwnselfLeft: ' + isOwnselfLeft)
     console.log('2. isPartnerOnline: ' + isPartnerOnline)
     console.log('3. isPartnerLeft: ' + isPartnerLeft)
     console.log('========================================')
-  }, [partneruuid, isOwnselfLeft, isPartnerOnline, isPartnerLeft])
+  }, [partneruuid, isOwnselfLeft, isPartnerOnline, isPartnerLeft]) */
 
   const renderPartnerOfflineAlertDialog = () => {
     return (

--- a/frontend/src/pages/CollaborationPage.js
+++ b/frontend/src/pages/CollaborationPage.js
@@ -188,6 +188,15 @@ const CollaborationPage = () => {
 
   useEffect(() => {}, [partneruuid])
 
+  useEffect(() => {
+    console.log('========================================')
+    console.log('partneruuid: ' + partneruuid)
+    console.log('1. isOwnselfLeft: ' + isOwnselfLeft)
+    console.log('2. isPartnerOnline: ' + isPartnerOnline)
+    console.log('3. isPartnerLeft: ' + isPartnerLeft)
+    console.log('========================================')
+  }, [partneruuid, isOwnselfLeft, isPartnerOnline, isPartnerLeft])
+
   const renderPartnerOfflineAlertDialog = () => {
     return (
       <AlertDialog


### PR DESCRIPTION
**Collaboration Page**
- Fix frontend bug with variable `isOwnselfLeft`

> Bug:
> - Both person A and B are in the room for 20 mins, with 10 mins remaining.
> - I refreshed person B's page, and because jwt expires, it logs out.
> - Person A's jwt should also have expired but I did not refresh the page.
> - Person A side shows the dialog that "partner has disconnected".
> - Person B logs in and shows the dialog that "partner has left" (but that is not the case). I click OK and cancel the review. Then the page refreshes and I am brought back into the same room as Person A with 10 mins remaining.

> I replicated the above bug again, this time round I refreshed person A's page:
> - Both person A and B are in the room for 26 mins, with 4 mins remaining.
> - I refreshed person A's page, and because jwt expires, it logs out.
> - Person B's jwt should also have expired but I did not refresh the page.
> - Person B side shows the dialog that "partner has disconnected".
> - Person A logs in and shows the dialog that "partner has left" (but that is not the case). I click OK and then cancel the review. Then the page refreshes and I am brought back into the same room as Person B with 4 mins remaining.

> **Note:** As discussed with Bing Cheng, we think that it is best to extend the jwt token by 30 mins after both parties are matched and join the room.

- Sort codes for clarity (to assist me in seeing where I should actually type in the console logs)
- Add console logs to catch matching bug (but commented out for now)

**ReviewPartnerDialog**
- Pass `replace: true` to navigate after review (missed this out previously)

**FindMatch Component**
- Add console logs to catch matching bug (but commented out for now)