### PR TITLE
Prevent users from using PeerPrep on multiple devices

### DIFF
--- a/frontend/src/api/matchingService.js
+++ b/frontend/src/api/matchingService.js
@@ -1,7 +1,10 @@
 import axios from 'axios'
+import { getUser } from './userService'
 import { URL_MATCH_SVC } from '../utils/configs'
 
 export const findMatch = async (uuid, socketID, difficulty) => {
+  // Crucial to make sure the user's JWT is still valid when initiating a find-match operation.
+  await getUser()
   const res = await axios.post(URL_MATCH_SVC, {
     uuid,
     socketID,

--- a/frontend/src/api/reviewService.js
+++ b/frontend/src/api/reviewService.js
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import { getUser } from './userService'
 import { URL_REVIEW_SVC } from '../utils/configs'
 
 export const getReviewStats = async (userId) => {
@@ -11,6 +12,7 @@ export const getReviewStats = async (userId) => {
 }
 
 export const createReviewStats = async (revieweeid, reviewerid, scores) => {
+  await getUser() // verify user is logged in first
   await axios.post(URL_REVIEW_SVC, {
     revieweeid,
     reviewerid,

--- a/frontend/src/api/userService.js
+++ b/frontend/src/api/userService.js
@@ -65,7 +65,11 @@ export const loginUser = async (username, password) => {
 export const extendJWTExpiration = async (additionalMinutes) => {
   const token = getJWT()
   if (token) {
-    Cookies.set(COOKIES_AUTH_TOKEN, token, { expires: new Date(getJWTExpiry().getTime() + (additionalMinutes * ONE_MINUTE_IN_MS)) }) // Add additional 20 mins to the current JWT time, total 35 mins
+    Cookies.set(COOKIES_AUTH_TOKEN, token, {
+      expires: new Date(
+        getJWTExpiry().getTime() + additionalMinutes * ONE_MINUTE_IN_MS
+      ),
+    }) // Add additional 20 mins to the current JWT time, total 35 mins
   }
 }
 

--- a/frontend/src/api/userService.js
+++ b/frontend/src/api/userService.js
@@ -13,7 +13,7 @@ import {
   AUTH_REDIRECT,
 } from '../utils/constants'
 import { getJWTExpiry } from '../utils/main'
-import { loginUrl } from '../utils/routeConstants'
+import { loginUrl, param_forcedLogout } from '../utils/routeConstants'
 
 // custom axios instance with request and response interceptors to handle auth
 const axiosWithAuth = axios.create()
@@ -42,7 +42,9 @@ axiosWithAuth.interceptors.response.use(
     ) {
       window.localStorage.setItem(AUTH_REDIRECT, window.location.pathname)
       Cookies.remove(COOKIES_AUTH_TOKEN)
-      window.location.replace(`${window.location.origin}${loginUrl}`)
+      window.location.replace(
+        `${window.location.origin}${loginUrl}?${param_forcedLogout}=true`
+      )
     }
 
     // still return the original rejected promise - don't swallow it up and let the request silently fail...

--- a/frontend/src/components/SnackbarAlert.js
+++ b/frontend/src/components/SnackbarAlert.js
@@ -11,6 +11,7 @@ const SnackbarAlert = ({
   setAlertOpen,
   severity, // values for the respective alert design: error, warning, info, success
   alertMsg,
+  autoHideDuration = 5000,
 }) => {
   const handleClose = (event, reason) => {
     if (reason === 'clickaway') {
@@ -24,7 +25,7 @@ const SnackbarAlert = ({
     <Snackbar
       anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
       open={alertOpen}
-      autoHideDuration={5000}
+      autoHideDuration={autoHideDuration}
       onClose={handleClose}
     >
       <Alert onClose={handleClose} severity={severity} sx={{ width: '100%' }}>

--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -1,14 +1,15 @@
 import { useState, useEffect } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useNavigate, useLocation } from 'react-router-dom'
 import { Button } from '@mui/material'
 import UserAuth from '../components/UserAuth'
+import SnackbarAlert from '../components/SnackbarAlert'
 import {
   AUTH_REDIRECT,
   STATUS_CODE_SUCCESS,
   STATUS_CODE_BAD_REQUEST,
   STATUS_CODE_UNAUTHORIZED,
 } from '../utils/constants'
-import { homeUrl } from '../utils/routeConstants'
+import { homeUrl, param_forcedLogout } from '../utils/routeConstants'
 import { loginUser, isUserLoggedIn } from '../api/userService'
 
 const LoginPage = () => {
@@ -16,8 +17,20 @@ const LoginPage = () => {
   const [dialogTitle, setDialogTitle] = useState('')
   const [dialogMsg, setDialogMsg] = useState('')
   const [isLoginSuccess, setIsLoginSuccess] = useState(false)
+  const [forcedLogoutAlertOpen, setForcedLogoutAlertOpen] = useState(false)
 
   const navigate = useNavigate()
+  const { search } = useLocation()
+
+  useEffect(() => {
+    // reset the state of the toast each time the search params change
+    setForcedLogoutAlertOpen(false)
+
+    const params = new URLSearchParams(search)
+    if (params.get(param_forcedLogout)) {
+      setForcedLogoutAlertOpen(true)
+    }
+  }, [search])
 
   useEffect(() => {
     if (isUserLoggedIn()) {
@@ -70,20 +83,34 @@ const LoginPage = () => {
     )
   }
 
-  return (
-    <UserAuth
-      pageTitle="Log in"
-      ctaText="Log in"
-      toggleText="Create an account"
-      toggleDestination="/signup"
-      handleAuth={handleLogin}
-      isDialogOpen={isDialogOpen}
-      closeDialog={closeDialog}
-      dialogTitle={dialogTitle}
-      dialogMsg={dialogMsg}
-      isAuthSuccess={isLoginSuccess}
-      redirectButton={redirectButton}
+  const renderForcedLoggedOutAlert = () => (
+    <SnackbarAlert
+      alertOpen={forcedLogoutAlertOpen}
+      setAlertOpen={setForcedLogoutAlertOpen}
+      autoHideDuration={8000}
+      severity="error"
+      alertMsg={`You have been logged out of your session.
+          You may be logged in on another device or your session may have expired.`}
     />
+  )
+
+  return (
+    <>
+      <UserAuth
+        pageTitle="Log in"
+        ctaText="Log in"
+        toggleText="Create an account"
+        toggleDestination="/signup"
+        handleAuth={handleLogin}
+        isDialogOpen={isDialogOpen}
+        closeDialog={closeDialog}
+        dialogTitle={dialogTitle}
+        dialogMsg={dialogMsg}
+        isAuthSuccess={isLoginSuccess}
+        redirectButton={redirectButton}
+      />
+      {renderForcedLoggedOutAlert()}
+    </>
   )
 }
 

--- a/frontend/src/utils/routeConstants.js
+++ b/frontend/src/utils/routeConstants.js
@@ -5,3 +5,6 @@ export const homeUrl = `${baseUrl}home`
 export const profileUrl = `${baseUrl}profile`
 export const collabUrl = `${baseUrl}collaborate`
 export const publicRoutes = [baseUrl, signupUrl, loginUrl]
+
+// Query parameters
+export const param_forcedLogout = 'forcedLogout'

--- a/matching-service/controller/match-controller.js
+++ b/matching-service/controller/match-controller.js
@@ -1,6 +1,7 @@
 import {
   findMatchInCache,
   deleteMatchInCache,
+  isUserInCache,
 } from '../model/redis-repository.js'
 
 import {
@@ -19,6 +20,12 @@ export const findMatch = async (req, res) => {
       return res
         .status(400)
         .json({ message: 'One or more fields are missing!' })
+    }
+
+    if (await isUserInCache(uuid)) {
+      return res
+        .status(409)
+        .json({ message: 'User is already in a matching queue.' })
     }
 
     const cacheUser = await findMatchInCache(difficulty, uuid, socketID)
@@ -106,7 +113,9 @@ export const updateRoom = async (req, res) => {
   console.log('PATCH /api/room ' + JSON.stringify(req.body))
   try {
     const room = await _updateRoom(req.params.room_id, req.body)
-    return res.status(200).json({ message: 'Room updated successfully!', data: room })
+    return res
+      .status(200)
+      .json({ message: 'Room updated successfully!', data: room })
   } catch (err) {
     return res.status(400).json({ message: 'Error with updating room!' })
   }

--- a/matching-service/model/redis-repository.js
+++ b/matching-service/model/redis-repository.js
@@ -48,3 +48,20 @@ export const deleteMatchInCache = async (difficulty, uuid, socketID) => {
     return false
   }
 }
+
+export const isUserInCache = async (uuid) => {
+  try {
+    // given a single match queue, checks if the user is already in the queue
+    const isUserInQueue = (queue) => queue.some((match) => match.uuid === uuid)
+
+    const difficulties = ['Easy', 'Medium', 'Hard']
+    const cachedQueues = await Promise.all(
+      difficulties.map((d) => client.get(d))
+    )
+    // check every queue to see if the user is one any of them
+    return cachedQueues.map(JSON.parse).some(isUserInQueue)
+  } catch (err) {
+    console.error('Error searching cache for user.', err)
+    throw err // re-throw to let caller handle
+  }
+}

--- a/user-service/constants.js
+++ b/user-service/constants.js
@@ -2,6 +2,7 @@ import 'dotenv/config'
 
 export const REDIS_JWT_KEY = 'invalid_jwt'
 export const JWT_EXPIRY = 15 * 60 // 15 mins in seconds
+export const REDIS_USER_KEY = 'curr_jwt_user'
 
 export const URI_MATCHING_SVC =
   process.env.URI_MATCHING_SVC || 'http://localhost:8200'

--- a/user-service/model/redis-repository.js
+++ b/user-service/model/redis-repository.js
@@ -1,5 +1,5 @@
 import { createClient } from 'redis'
-import { REDIS_JWT_KEY, JWT_EXPIRY } from '../constants.js'
+import { REDIS_JWT_KEY, JWT_EXPIRY, REDIS_USER_KEY } from '../constants.js'
 import 'dotenv/config'
 
 const REDIS_URI = process.env.REDIS_URI || 'localhost:6379'
@@ -12,15 +12,30 @@ client.on('connect', () => console.log('REDIS CONNECTED'))
 await client.connect()
 
 const getTokenKey = (token) => `${REDIS_JWT_KEY}_${token}`
+const getUserKey = (userId) => `${REDIS_USER_KEY}_${userId}`
 
+// Adds a JWT to the blacklist
 export const addJWT = async (token) => {
   const token_key = getTokenKey(token)
   await client.set(token_key, token)
   return client.expire(token_key, JWT_EXPIRY) // returns 1 if successfully set, 0 otherwise
 }
 
+// Checks if a JWT exists in the blacklist
 export const checkJWTExists = async (token) => {
   const token_key = getTokenKey(token)
   const isTokenBlacklisted = await client.get(token_key)
   return !!isTokenBlacklisted
+}
+
+// Retrieves a user's currently valid JWT
+export const getCurrUserJWT = async (userId) => {
+  return client.get(getUserKey(userId))
+}
+
+// Updates the user's currently valid JWT.
+export const setCurrUserJWT = async (userId, token) => {
+  const key = getUserKey(userId)
+  await client.set(key, token)
+  return client.expire(key, JWT_EXPIRY)
 }


### PR DESCRIPTION
When a user logs in on device A, user-svc will store the user's JWT in Redis. When a user then logs in on device B, user-svc will first retrieve the current JWT from redis and invalidate it. Then, it will update Redis with the new JWT. 

When the user tries to do stuff on device A, it should log him out and redirect him to the login page. This includes everytime he visits/goes to a private page, when he tries to find a match, and also when he tries to submit a review. The latter two actions are explicitly handled cos they don't involve a page transition, so the frontend doesn't actually re-validate JWTs when you try to do them.